### PR TITLE
Accept more languages

### DIFF
--- a/src/dc/WebsiteAnalyzer/WebsiteAnalyzerNLP.cls
+++ b/src/dc/WebsiteAnalyzer/WebsiteAnalyzerNLP.cls
@@ -14,7 +14,7 @@ XData Domain [ XMLNamespace = "http://www.intersystems.com/iknow" ]
 </data>
 <matching disabled="false" dropBeforeBuild="true" autoExecute="true" ignoreDictionaryErrors="true" />
 <metadata />
-<configuration name="WebsiteAnalyzerDomain.Configuration" detectLanguage="true" languages="en,pt" userDictionary="WebsiteAnalyzerDomain.Dictionary#1" summarize="true" maxConceptLength="0" />
+<configuration name="WebsiteAnalyzerDomain.Configuration" detectLanguage="true" languages="en,pt,nl,fr,de,es,ru,uk" userDictionary="WebsiteAnalyzerDomain.Dictionary#1" summarize="true" maxConceptLength="0" />
 <userDictionary name="WebsiteAnalyzerDomain.Dictionary#1" />
 </domain>
 }


### PR DESCRIPTION
miniscule update to the domain definition: when IRIS NLP uses Automatic Language Identification, the number of languages you add doesn't make much of a difference for performance / memory footprint, so why not just let it support a few more out of the box. I did it for my test so putting it in a PR was about as much effort :-)